### PR TITLE
Change hash substring to be 26 characters instead of 20.

### DIFF
--- a/lib/cleverbot.js
+++ b/lib/cleverbot.js
@@ -47,7 +47,7 @@ Cleverbot.prototype = {
     var clever = this;
     body = this.params;
     body.stimulus = message;
-    body.icognocheck = Cleverbot.digest(Cleverbot.encodeParams(body).substring(9,29));
+    body.icognocheck = Cleverbot.digest(Cleverbot.encodeParams(body).substring(9,35));
     var options = {
       host: 'www.cleverbot.com',
       port: 80,


### PR DESCRIPTION
Cleverbot released an update that requires the first 26 characters after `stimulus=` in the post body to be hashed for the `incognocheck` parameter. Previously it only required the first 20. Since the update, if you only hash 20 characters, you end up getting 'DENIED' back for the session ID.

This solves issue #2.
