### PR TITLE
Display Error Code when Cleverbot API is down. --Resolves Issue #6

### DIFF
--- a/lib/cleverbot.js
+++ b/lib/cleverbot.js
@@ -66,6 +66,7 @@ Cleverbot.prototype = {
         for(var i = 0, iLen = chunk_data.length;i<iLen;i++){
           clever.params[Cleverbot.parserKeys[i]] = responseHash[Cleverbot.parserKeys[i]] = chunk_data[i];
         }
+        if (res.statusCode >= 300) responseHash.message = 'Error: ' + res.statusCode;
         cb(responseHash);
       });
      });


### PR DESCRIPTION
When the API call returns a non-success status code replace the response message with "Error :" + Status Code that generated the error.

This resolves the problem when, on error, cleverbot saying "<html>", the first line of an HTML error page.
