### PR TITLE
403 Error fix

### DIFF
--- a/lib/cleverbot.js
+++ b/lib/cleverbot.js
@@ -56,7 +56,7 @@ Cleverbot.prototype = {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
         'Content-Length': Cleverbot.encodeParams(body).length,
-        'Cache-Control': 'no-cache',
+        'Cache-Control': 'no-cache'
       }
     };
     var req = http.request(options, function(res) {


### PR DESCRIPTION
It seems like adding in the 'Cache-Control': 'no-cache' option in fixes the 403 error that recently started happening in April 2014.

I tried a bunch of different headers to see if that fixes it, and boiled it down to this one.
