### PR TITLE
Reduce polution of the global namespace.

### DIFF
--- a/lib/cleverbot.js
+++ b/lib/cleverbot.js
@@ -30,7 +30,7 @@ Cleverbot.digest = function (body) {
 
 Cleverbot.encodeParams = function (a1) {
     var u = [];
-    for (x in a1) {
+    for (var x in a1) {
         if (a1[x] instanceof Array)
             u.push(x + "=" + encodeURIComponent(a1[x].join(",")));
         else if (a1[x] instanceof Object)
@@ -69,7 +69,7 @@ Cleverbot.prototype = {
 
     write: function (message, callback) {
         var clever = this;
-        body = this.params;
+        var body = this.params;
         body.stimulus = message;
         body.icognocheck = Cleverbot.digest(Cleverbot.encodeParams(body).substring(9, 35));
         var cookie_string = '';


### PR DESCRIPTION
Undeclared variables pollute the global namespace and are annoying to track down. This change adds var in-front of x in the for loop and the body variable preventing them from being attached to the global object. A long term solution to making sure a problem like this does not happen in the future could be adding 
```
"use strict";
```
to the top of the project.