### PR TITLE
fixed uc again, untested

### DIFF
--- a/lib/cleverbot.js
+++ b/lib/cleverbot.js
@@ -75,7 +75,7 @@ Cleverbot.prototype = {
     },
 
     path: function(){
-      var path = '/webservicemin?uc=777&';
+      var path = '/webservicemin?uc=UseOfficialAPI&';
       if(this.botapi) {
         path += ['botapi',this.botapi].join("=");
       } else {


### PR DESCRIPTION
Seems that Cleverbot changed their `uc` value again, this time to something that seems to be telling developers to use the official API. Hopefully they don't do something that prevents devs from using the webservicemin endpoint in the future.